### PR TITLE
Updating GUIDs to match new guidelines

### DIFF
--- a/HttpRequests/OnAttributeCollectionStart.json
+++ b/HttpRequests/OnAttributeCollectionStart.json
@@ -1,13 +1,13 @@
 {
     "type": "microsoft.graph.authenticationEvent.attributeCollectionStart",
-    "source": "/tenants/11111111-0000-0000-0000-000000000000/applications/44444444-0000-0000-0000-000000000000",
+    "source": "/tenants/aaaabbbb-0000-cccc-1111-dddd2222eeee/applications/00001111-aaaa-2222-bbbb-3333cccc4444",
     "data": {
         "@odata.type": "microsoft.graph.onAttributeCollectionStartCalloutData",
-        "tenantId": "11111111-0000-0000-0000-000000000000",
+        "tenantId": "aaaabbbb-0000-cccc-1111-dddd2222eeee",
         "authenticationEventListenerId": "22222222-0000-0000-0000-000000000000",
         "customAuthenticationExtensionId": "33333333-0000-0000-0000-000000000000",
         "authenticationContext": {
-            "correlationId": "12345678-0000-0000-0000-000000000000",
+            "correlationId": "aaaa0000-bb11-2222-33cc-444444dddddd",
             "client": {
                 "ip": "127.0.0.1",
                 "locale": "en-us",
@@ -16,13 +16,13 @@
             "protocol": "OAUTH2.0",
             "clientServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             },
             "resourceServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             }

--- a/HttpRequests/OnAttributeCollectionSubmit.json
+++ b/HttpRequests/OnAttributeCollectionSubmit.json
@@ -1,9 +1,9 @@
 {
     "type": "microsoft.graph.authenticationEvent.attributeCollectionSubmit",
-    "source": "/tenants/11111111-0000-0000-0000-000000000000/applications/44444444-0000-0000-0000-000000000000",
+    "source": "/tenants/aaaabbbb-0000-cccc-1111-dddd2222eeee/applications/00001111-aaaa-2222-bbbb-3333cccc4444",
     "data": {
         "@odata.type": "microsoft.graph.onAttributeCollectionSubmitCalloutData",
-        "tenantId": "11111111-0000-0000-0000-000000000000",
+        "tenantId": "aaaabbbb-0000-cccc-1111-dddd2222eeee",
         "authenticationEventListenerId": "22222222-0000-0000-0000-000000000000",
         "customAuthenticationExtensionId": "33333333-0000-0000-0000-000000000000",
         "authenticationContext": {
@@ -16,13 +16,13 @@
             "protocol": "OAUTH2.0",
             "clientServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             },
             "resourceServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             }

--- a/HttpRequests/OnEmailOtpSend.json
+++ b/HttpRequests/OnEmailOtpSend.json
@@ -1,9 +1,9 @@
 {
     "type": "microsoft.graph.authenticationEvent.emailOtpSend",
-    "source": "/tenants/11111111-0000-0000-0000-000000000000/applications/44444444-0000-0000-0000-000000000000",
+    "source": "/tenants/aaaabbbb-0000-cccc-1111-dddd2222eeee/applications/00001111-aaaa-2222-bbbb-3333cccc4444",
     "data": {
         "@odata.type": "microsoft.graph.onOtpSendCalloutData",
-        "tenantId": "11111111-0000-0000-0000-000000000000",
+        "tenantId": "aaaabbbb-0000-cccc-1111-dddd2222eeee",
         "authenticationEventListenerId": "22222222-0000-0000-0000-000000000000",
         "customAuthenticationExtensionId": "33333333-0000-0000-0000-000000000000",
         "otpContext": {
@@ -11,7 +11,7 @@
             "onetimecode": "23123456"
         },
         "authenticationContext": {
-            "correlationId": "12345678-0000-0000-0000-000000000000",
+            "correlationId": "aaaa0000-bb11-2222-33cc-444444dddddd",
             "client": {
                 "ip": "127.0.0.1",
                 "locale": "en-us",
@@ -21,13 +21,13 @@
             "requestType": "SignIn",
             "clientServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             },
             "resourceServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             }

--- a/HttpRequests/OnTokenIssuanceStart.json
+++ b/HttpRequests/OnTokenIssuanceStart.json
@@ -1,13 +1,13 @@
 {
     "type": "microsoft.graph.authenticationEvent.tokenIssuanceStart",
-    "source": "/tenants/11111111-0000-0000-0000-000000000000/applications/44444444-0000-0000-0000-000000000000",
+    "source": "/tenants/aaaabbbb-0000-cccc-1111-dddd2222eeee/applications/00001111-aaaa-2222-bbbb-3333cccc4444",
     "data": {
         "@odata.type": "microsoft.graph.onTokenIssuanceStartCalloutData",
-        "tenantId": "11111111-0000-0000-0000-000000000000",
+        "tenantId": "aaaabbbb-0000-cccc-1111-dddd2222eeee",
         "authenticationEventListenerId": "22222222-0000-0000-0000-000000000000",
         "customAuthenticationExtensionId": "33333333-0000-0000-0000-000000000000",
         "authenticationContext": {
-            "correlationId": "12345678-0000-0000-0000-000000000000",
+            "correlationId": "aaaa0000-bb11-2222-33cc-444444dddddd",
             "client": {
                 "ip": "127.0.0.1",
                 "locale": "en-us",
@@ -16,13 +16,13 @@
             "protocol": "OAUTH2.0",
             "clientServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             },
             "resourceServicePrincipal": {
                 "id": "33333333-0000-0000-0000-000000000000",
-                "appId": "44444444-0000-0000-0000-000000000000",
+                "appId": "00001111-aaaa-2222-bbbb-3333cccc4444",
                 "appDisplayName": "My Test application",
                 "displayName": "My Test application"
             },


### PR DESCRIPTION
As part of SFI, we need to be conscious of the GUIDs being made visible in docs, even if the GUIDs are known to be fake.

This PR scrubs GUIDs associated with identified sensitive terms as part of the SFI effort, namely appId, tenantid, correlation id.